### PR TITLE
Minor changes to use FastGlobalRegistration as a library

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -5,6 +5,12 @@ project(FastGlobalRegistration)
 set(FastGlobalRegistration_VERSION_MAJOR "1")
 set(FastGlobalRegistration_VERSION_MINOR "0")
 
+# Build either a STATIC or SHARED library
+if (NOT FastGlobalRegistration_LINK_MODE)
+  set(FastGlobalRegistration_LINK_MODE "STATIC")
+endif(NOT FastGlobalRegistration_LINK_MODE)
+message(STATUS "Libary linkage will be " ${FastGlobalRegistration_LINK_MODE})
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # set include directories

--- a/source/FastGlobalRegistration/CMakeLists.txt
+++ b/source/FastGlobalRegistration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(FastGlobalRegistrationLib SHARED app.cpp app.h)
+add_library(FastGlobalRegistrationLib ${FastGlobalRegistration_LINK_MODE} app.cpp app.h)
 add_executable(FastGlobalRegistration main.cpp)
 add_executable(Evaluation evaluation.cpp)
 TARGET_LINK_LIBRARIES(FastGlobalRegistration FastGlobalRegistrationLib)

--- a/source/FastGlobalRegistration/CMakeLists.txt
+++ b/source/FastGlobalRegistration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(FastGlobalRegistrationLib STATIC app.cpp app.h)
+add_library(FastGlobalRegistrationLib SHARED app.cpp app.h)
 add_executable(FastGlobalRegistration main.cpp)
 add_executable(Evaluation evaluation.cpp)
 TARGET_LINK_LIBRARIES(FastGlobalRegistration FastGlobalRegistrationLib)

--- a/source/FastGlobalRegistration/app.cpp
+++ b/source/FastGlobalRegistration/app.cpp
@@ -112,7 +112,6 @@ void CApp::SearchKDTree(KDTree* tree, const T& input,
 
 void CApp::AdvancedMatching()
 {
-  printf("Values are: div_factor = %g, use_absolute_scale = %g, max_corr_dist = %g, iteration_number = %g, tuple_scale = %g, tuple_max_cnt = %g\n", double(div_factor_), double(use_absolute_scale_), double(max_corr_dist_), double(iteration_number_), double(tuple_scale_), double(tuple_max_cnt_));
 	int fi = 0;
 	int fj = 1;
 

--- a/source/FastGlobalRegistration/app.cpp
+++ b/source/FastGlobalRegistration/app.cpp
@@ -108,6 +108,7 @@ void CApp::SearchKDTree(KDTree* tree, const T& input,
 
 void CApp::AdvancedMatching()
 {
+  printf("Values are: div_factor = %g, use_absolute_scale = %g, max_corr_dist = %g, iteration_number = %g, tuple_scale = %g, tuple_max_cnt = %g\n", double(div_factor_), double(use_absolute_scale_), double(max_corr_dist_), double(iteration_number_), double(tuple_scale_), double(tuple_max_cnt_));
 	int fi = 0;
 	int fj = 1;
 
@@ -243,7 +244,7 @@ void CApp::AdvancedMatching()
 		int rand0, rand1, rand2;
 		int idi0, idi1, idi2;
 		int idj0, idj1, idj2;
-		float scale = TUPLE_SCALE;
+		float scale = tuple_scale_;
 		int ncorr = corres.size();
 		int number_of_trial = ncorr * 100;
 		std::vector<std::pair<int, int>> corres_tuple;
@@ -291,7 +292,7 @@ void CApp::AdvancedMatching()
 				cnt++;
 			}
 
-			if (cnt >= TUPLE_MAX_CNT)
+			if (cnt >= tuple_max_cnt_)
 				break;
 		}
 
@@ -364,7 +365,7 @@ void CApp::NormalizePoints()
 	}
 
 	//// mean of the scale variation
-	if (USE_ABSOLUTE_SCALE) {
+	if (use_absolute_scale_) {
 		GlobalScale = 1.0f;
 		StartScale = scale;
 	} else {
@@ -385,12 +386,12 @@ void CApp::NormalizePoints()
 	}
 }
 
-double CApp::OptimizePairwise(bool decrease_mu_, int numIter_)
+double CApp::OptimizePairwise(bool decrease_mu_)
 {
 	printf("Pairwise rigid pose optimization\n");
 
 	double par;
-	int numIter = numIter_;
+	int numIter = iteration_number_;
 	TransOutput_ = Eigen::Matrix4f::Identity();
 
 	par = StartScale;
@@ -418,8 +419,8 @@ double CApp::OptimizePairwise(bool decrease_mu_, int numIter_)
 		// graduated non-convexity.
 		if (decrease_mu_)
 		{
-			if (itr % 4 == 0 && par > MAX_CORR_DIST) {
-				par /= DIV_FACTOR;
+			if (itr % 4 == 0 && par > max_corr_dist_) {
+				par /= div_factor_;
 			}
 		}
 
@@ -583,7 +584,7 @@ void CApp::BuildDenseCorrespondence(const Eigen::Matrix4f& trans,
 	{
 		SearchKDTree(&feature_tree_i, pcj[j], ind, dist, 1);
 		float dist_j = sqrt(dist[0]);
-		if (dist_j / GlobalScale < MAX_CORR_DIST / 2.0)
+		if (dist_j / GlobalScale < max_corr_dist_ / 2.0)
 			corres.push_back(std::pair<int, int>(ind[0], j));
 	}
 }

--- a/source/FastGlobalRegistration/app.cpp
+++ b/source/FastGlobalRegistration/app.cpp
@@ -29,6 +29,10 @@
 
 #include "app.h"
 
+using namespace Eigen;
+using namespace std;
+using namespace fgr;
+
 void CApp::ReadFeature(const char* filepath)
 {
 	Points pts;
@@ -143,10 +147,10 @@ void CApp::AdvancedMatching()
 	std::vector<float> dis;
 	std::vector<int> ind;
 
-	std::vector<std::pair<int, int>> corres;
-	std::vector<std::pair<int, int>> corres_cross;
-	std::vector<std::pair<int, int>> corres_ij;
-	std::vector<std::pair<int, int>> corres_ji;
+	std::vector<std::pair<int, int> > corres;
+	std::vector<std::pair<int, int> > corres_cross;
+	std::vector<std::pair<int, int> > corres_ij;
+	std::vector<std::pair<int, int> > corres_ji;
 
 	///////////////////////////
 	/// INITIAL MATCHING
@@ -195,8 +199,8 @@ void CApp::AdvancedMatching()
 		// build data structure for cross check
 		corres.clear();
 		corres_cross.clear();
-		std::vector<std::vector<int>> Mi(nPti);
-		std::vector<std::vector<int>> Mj(nPtj);
+		std::vector<std::vector<int> > Mi(nPti);
+		std::vector<std::vector<int> > Mj(nPtj);
 
 		int ci, cj;
 		for (int i = 0; i < ncorres_ij; ++i)
@@ -247,7 +251,7 @@ void CApp::AdvancedMatching()
 		float scale = tuple_scale_;
 		int ncorr = corres.size();
 		int number_of_trial = ncorr * 100;
-		std::vector<std::pair<int, int>> corres_tuple;
+		std::vector<std::pair<int, int> > corres_tuple;
 
 		int cnt = 0;
 		int i;
@@ -305,7 +309,7 @@ void CApp::AdvancedMatching()
 
 	if (swapped)
 	{
-		std::vector<std::pair<int, int>> temp;
+		std::vector<std::pair<int, int> > temp;
 		for (int i = 0; i < corres.size(); i++)
 			temp.push_back(std::pair<int, int>(corres[i].second, corres[i].first));
 		corres.clear();
@@ -597,7 +601,7 @@ void CApp::Evaluation(const char* gth, const char* estimation, const char *outpu
 	int fi = 0;
 	int fj = 1;
 
-	std::vector<std::pair<int, int>> corres;
+	std::vector<std::pair<int, int> > corres;
 	Eigen::Matrix4f gth_trans = ReadTrans(gth);
 	BuildDenseCorrespondence(gth_trans, corres);
 	printf("Groundtruth correspondences [%d-%d] : %d\n", fi, fj, 

--- a/source/FastGlobalRegistration/app.h
+++ b/source/FastGlobalRegistration/app.h
@@ -50,6 +50,18 @@ typedef std::vector<std::pair<int, int>> Correspondences;
 
 class CApp{
 public:
+	CApp(double div_factor         = DIV_FACTOR,
+	    bool    use_absolute_scale = USE_ABSOLUTE_SCALE,
+	    double  max_corr_dist      = MAX_CORR_DIST,
+	    int     iteration_number   = ITERATION_NUMBER,
+	    float   tuple_scale        = TUPLE_SCALE,
+	    int     tuple_max_cnt      = TUPLE_MAX_CNT):
+		div_factor_(div_factor),
+		use_absolute_scale_(use_absolute_scale),
+		max_corr_dist_(max_corr_dist),
+		iteration_number_(iteration_number),
+		tuple_scale_(tuple_scale),
+		tuple_max_cnt_(tuple_max_cnt){}
 	void LoadFeature(const Points& pts, const Feature& feat);
 	void ReadFeature(const char* filepath);
 	void NormalizePoints();
@@ -57,7 +69,7 @@ public:
 	Eigen::Matrix4f ReadTrans(const char* filepath);
 	void WriteTrans(const char* filepath);
 	Matrix4f GetOutputTrans();
-	double OptimizePairwise(bool decrease_mu_, int numIter_);
+	double OptimizePairwise(bool decrease_mu_);
 	void Evaluation(const char* gth, const char* estimation, const char *output);
 
 private:
@@ -86,4 +98,11 @@ private:
 		std::vector<int>& indices,
 		std::vector<float>& dists,
 		int nn);
+
+	double div_factor_;
+	bool   use_absolute_scale_;
+	double max_corr_dist_;
+	int    iteration_number_;
+	float  tuple_scale_;
+	int    tuple_max_cnt_;
 };

--- a/source/FastGlobalRegistration/app.h
+++ b/source/FastGlobalRegistration/app.h
@@ -39,14 +39,12 @@
 #define TUPLE_SCALE			0.95	// Similarity measure used for tuples of feature points.
 #define TUPLE_MAX_CNT		1000	// Maximum tuple numbers.
 
-
-using namespace Eigen;
-using namespace std;
-
-typedef vector<Vector3f> Points;
-typedef vector<VectorXf> Feature;
-typedef flann::Index<flann::L2<float>> KDTree;
-typedef std::vector<std::pair<int, int>> Correspondences;
+namespace fgr {
+  
+typedef std::vector<Eigen::Vector3f> Points;
+typedef std::vector<Eigen::VectorXf> Feature;
+typedef flann::Index<flann::L2<float> > KDTree;
+typedef std::vector<std::pair<int, int> > Correspondences;
 
 class CApp{
 public:
@@ -68,16 +66,16 @@ public:
 	void AdvancedMatching();
 	Eigen::Matrix4f ReadTrans(const char* filepath);
 	void WriteTrans(const char* filepath);
-	Matrix4f GetOutputTrans();
+	Eigen::Matrix4f GetOutputTrans();
 	double OptimizePairwise(bool decrease_mu_);
 	void Evaluation(const char* gth, const char* estimation, const char *output);
 
 private:
 	// containers
-	vector<Points> pointcloud_;
-	vector<Feature> features_;
-	Matrix4f TransOutput_;
-	vector<pair<int, int>> corres_;
+	std::vector<Points> pointcloud_;
+	std::vector<Feature> features_;
+	Eigen::Matrix4f TransOutput_;
+	std::vector<std::pair<int, int> > corres_;
 
 	// for normalization
 	Points Means;
@@ -91,7 +89,7 @@ private:
 			Correspondences& corres);
 	
 	template <typename T>
-	void BuildKDTree(const vector<T>& data, KDTree* tree);
+	void BuildKDTree(const std::vector<T>& data, KDTree* tree);
 	template <typename T>
 	void SearchKDTree(KDTree* tree,
 		const T& input,
@@ -106,3 +104,5 @@ private:
 	float  tuple_scale_;
 	int    tuple_max_cnt_;
 };
+
+}

--- a/source/FastGlobalRegistration/evaluation.cpp
+++ b/source/FastGlobalRegistration/evaluation.cpp
@@ -36,7 +36,7 @@ int main(int argc, char * argv[])
         printf("%s [feature_01] [feature_02] [transform_gth_log] [transform_est_txt] [eval_txt]\n", argv[0]);
 		return 0;
 	}
-        fgr::CApp app;
+	fgr::CApp app;
 	app.ReadFeature(argv[1]);
 	app.ReadFeature(argv[2]);
 	app.Evaluation(argv[3], argv[4], argv[5]);

--- a/source/FastGlobalRegistration/evaluation.cpp
+++ b/source/FastGlobalRegistration/evaluation.cpp
@@ -36,7 +36,7 @@ int main(int argc, char * argv[])
         printf("%s [feature_01] [feature_02] [transform_gth_log] [transform_est_txt] [eval_txt]\n", argv[0]);
 		return 0;
 	}
-	CApp app;
+        fgr::CApp app;
 	app.ReadFeature(argv[1]);
 	app.ReadFeature(argv[2]);
 	app.Evaluation(argv[3], argv[4], argv[5]);

--- a/source/FastGlobalRegistration/main.cpp
+++ b/source/FastGlobalRegistration/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 	app.ReadFeature(argv[2]);
 	app.NormalizePoints();
 	app.AdvancedMatching();
-	app.OptimizePairwise(true, ITERATION_NUMBER);
+	app.OptimizePairwise(true);
 	app.WriteTrans(argv[3]);
 
 	return 0;

--- a/source/FastGlobalRegistration/main.cpp
+++ b/source/FastGlobalRegistration/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 		printf("%s [feature_01] [feature_02] [transform_output_txt]\n", argv[0]);
 		return 0;
 	}
-        fgr::CApp app;
+	fgr::CApp app;
 	app.ReadFeature(argv[1]);
 	app.ReadFeature(argv[2]);
 	app.NormalizePoints();

--- a/source/FastGlobalRegistration/main.cpp
+++ b/source/FastGlobalRegistration/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 		printf("%s [feature_01] [feature_02] [transform_output_txt]\n", argv[0]);
 		return 0;
 	}
-	CApp app;
+        fgr::CApp app;
 	app.ReadFeature(argv[1]);
 	app.ReadFeature(argv[2]);
 	app.NormalizePoints();


### PR DESCRIPTION
Thank you for the very nice FastGlobalRegistration library. I am integrating it into our NASA Ames Stereo Pipeline (https://ti.arc.nasa.gov/tech/asr/groups/intelligent-robotics/ngt/stereo/), more exactly, into our alignment tool for 3D terrain models created from stereo for planetary bodies, where we already support ICP, and we thought having FastGlobalRegistration as an option could be nice. 

I made a set of small changes to the code to make it easier to call from our tools. You are very welcome to consider if they improve the library.

If you would like to adopt some of them, but not all, you can point them out to me, and I can make a finger-grained pulled request. Here is what I changed:

- Added the option to build the library as dynamic and not only static
- Added a constructor, so that the user can set the values of the parameters rather than using hard-coded values
- Added a namespace, to avoid conflicts when mixing and building with other code
- Made it compile with pre-C_++-11 compilers (basically instead of "vector<vector<int>>" I switched to "vector<vector<int> >". I know that you may not care much for older compilers, but really, this is the only C++-11 feature your library uses, and is likely not essential.

Do let me know what you think, and if I should make any modification to this request. 



